### PR TITLE
Fix AI tools modal not opening from media library

### DIFF
--- a/assets/js/attachment-fields-vanilla.js
+++ b/assets/js/attachment-fields-vanilla.js
@@ -142,12 +142,23 @@ function $1(selector, context = document) {
     function initAITools() {
         try {
             const buttons = $('.pic-pilot-launch-modal-btn:not(.bound)');
-            
-            // Mark buttons as bound
+
             buttons.forEach(button => {
                 button.classList.add('bound');
+
+                // Attach direct click handler in case event delegation fails
+                button.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const attachmentId = this.dataset.attachmentId;
+                    if (attachmentId) {
+                        openAIToolsModal(attachmentId);
+                    } else {
+                        console.error('PicPilot: No attachment ID found');
+                    }
+                });
             });
-            
+
         } catch (error) {
             console.error('PicPilot: Error in initAITools:', error);
         }


### PR DESCRIPTION
## Summary
- bind click handlers directly to AI Tools button
- allow modal to open reliably from the media library

## Testing
- `php -l $(git ls-files '*.php')`

------
https://chatgpt.com/codex/tasks/task_e_688ade9f0a64832393fda3944dfd8d33